### PR TITLE
lookup reline instead of readline history

### DIFF
--- a/lib/every_day_irb.rb
+++ b/lib/every_day_irb.rb
@@ -76,6 +76,7 @@ module EveryDayIrb
         number_of_lines = context.instance_variable_get(:@line_no)
       end
     end
-    Reline::HISTORY.entries[-number_of_lines...-1]*"\n"
+
+    (Reline rescue Readline)::HISTORY.entries[-number_of_lines...-1]*"\n"
   end
 end

--- a/lib/every_day_irb.rb
+++ b/lib/every_day_irb.rb
@@ -76,6 +76,6 @@ module EveryDayIrb
         number_of_lines = context.instance_variable_get(:@line_no)
       end
     end
-    Readline::HISTORY.entries[-number_of_lines...-1]*"\n"
+    Reline::HISTORY.entries[-number_of_lines...-1]*"\n"
   end
 end


### PR DESCRIPTION
Hello,

seems like `irb` now uses `reline` gem instead of `readline`. It is supposed to have identical API but the constant name is `Reline` instead of `Readline`. Looks like switch was made here: [IRB relies on reline.gem now](https://github.com/ruby/irb/commit/61e2627df926b751897b7b6a4876f889a7e0510f#diff-58da29639f1c7297516df4b5c8e225f28060694f0c644578e2c46a05b2ea03c6).

EDIT: Maybe this could be a check whatever Readilne/Reline constant is defined. But I see Readline is included somewhere else (outside of `every_day_irb`) as it is present in irbtools but not in irb session.

EDIT2: its there: [irbtools/libraries.rb#L42](https://github.com/janlelis/irbtools/blob/109381edd9a8bde5b73410df6b23dfae4d6d864a/lib/irbtools/libraries.rb#L42). As `reline` is default gem since 2.7 this one probably should also switch to `reline` (I don't understand however why its explicitly required so won't open PR).

Cheers
🍷 